### PR TITLE
torch.load() function need the map_location to make it load right

### DIFF
--- a/reid/modeling/baseline.py
+++ b/reid/modeling/baseline.py
@@ -59,8 +59,8 @@ class Baseline(nn.Module):
         return feat
 
 
-    def load_param(self, trained_path):
-        param_dict = torch.load(trained_path)
+    def load_param(self, trained_path, map_location="cpu"):
+        param_dict = torch.load(trained_path, map_location)
         for i in param_dict:
             if 'classifier' in i:
                 continue

--- a/search.py
+++ b/search.py
@@ -35,7 +35,7 @@ def detect(cfg,
     ############# 行人重识别模型初始化 #############
     query_loader, num_query = make_data_loader(reidCfg)
     reidModel = build_model(reidCfg, num_classes=10126)
-    reidModel.load_param(reidCfg.TEST.WEIGHT)
+    reidModel.load_param(reidCfg.TEST.WEIGHT, device)
     reidModel.to(device).eval()
 
     query_feats = []


### PR DESCRIPTION
> error

when using win10 to run this program:

```shell
Namespace(cfg='cfg/yolov3.cfg', conf_thres=0.1, data='data/coco.data', dist_thres=1.0, fourcc='mp4v', half=False, images='data/samples', img_size=416, nms_thres=0.4, output='output', query='query', webcam=False, weights='weights/yolov3.weights')
Using CPU

Dataset statistics:
  ----------------------------------------
  subset   | # ids | # images | # cameras
  ----------------------------------------
  query    |     1 |        2 |         2
  ----------------------------------------
Traceback (most recent call last):
  File "search.py", line 226, in <module>
    output=opt.output)
  File "search.py", line 38, in detect
    reidModel.load_param(reidCfg.TEST.WEIGHT)
  File "J:\workspace\python\person_search_demo\reid\modeling\baseline.py", line 63, in load_param
    param_dict = torch.load(trained_path)
  File "C:\ProgramData\Anaconda3\lib\site-packages\torch\serialization.py", line 386, in load
    return _load(f, map_location, pickle_module, **pickle_load_args)
  File "C:\ProgramData\Anaconda3\lib\site-packages\torch\serialization.py", line 573, in _load
    result = unpickler.load()
  File "C:\ProgramData\Anaconda3\lib\site-packages\torch\serialization.py", line 536, in persistent_load
    deserialized_objects[root_key] = restore_location(obj, location)
  File "C:\ProgramData\Anaconda3\lib\site-packages\torch\serialization.py", line 119, in default_restore_location
    result = fn(storage, location)
  File "C:\ProgramData\Anaconda3\lib\site-packages\torch\serialization.py", line 95, in _cuda_deserialize
    device = validate_cuda_device(location)
  File "C:\ProgramData\Anaconda3\lib\site-packages\torch\serialization.py", line 79, in validate_cuda_device
    raise RuntimeError('Attempting to deserialize object on a CUDA '
RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location='cpu' to map your storages to the CPU.
```

> fix

must using `map_location="cpu"` to make the `torch.load()` right.
